### PR TITLE
Add Heroku buildpack scripts to install Prism

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# bin/compile <build-dir> <cache-dir>
+
+set -eu
+
+BUILD_DIR=$1
+CACHE_DIR=$2
+
+PLATFORM="linux"
+FILENAME="prism-cli-$PLATFORM"
+URL="https://github.com/stoplightio/prism/releases/latest/download/$FILENAME"
+
+mkdir -p $CACHE_DIR
+mkdir -p $BUILD_DIR/vendor/prism/bin
+
+if ! [ -e $CACHE_DIR/$FILENAME ]; then
+  echo "-----> Downloading Prism binary"
+  curl $URL -s -Lo $CACHE_DIR/$FILENAME
+fi
+
+cp $CACHE_DIR/$FILENAME $BUILD_DIR/vendor/prism/bin/prism
+chmod +x $BUILD_DIR/vendor/prism/bin/prism
+
+# populate profile.d
+PROFILE_PATH="$BUILD_DIR/.profile.d/prism.sh"
+mkdir -p $(dirname $PROFILE_PATH)
+echo 'export PATH="$HOME/vendor/prism/bin:$PATH"' >> $PROFILE_PATH
+
+echo "-----> Prism is successfully installed"

--- a/bin/detect
+++ b/bin/detect
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# bin/use <build-dir>
+
+echo "Prism" && exit 0

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# bin/release <build-dir>
+
+echo "--- {}"


### PR DESCRIPTION
These buildpack scripts conform to the Heroku
[Buildpack API][1].

[1]: https://devcenter.heroku.com/articles/buildpack-api