### PR TITLE
Fix default branch excluded from commit msg checks

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
       - synchronize
   push:
     branches-ignore:
-      - master
+      - main
 
 jobs:
   check-commit-message-style:


### PR DESCRIPTION
The previous commit wrongly specified `master` as the branch to be
excluded from the git commit message checks.