### PR TITLE
Add shell script linting using ShellCheck

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,27 @@
+---
+name: reviewdog
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  push:
+
+jobs:
+
+  shellcheck:
+    name: runner / shellcheck
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1.15.0
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-check
+          path: "./bin"
+          pattern: |
+            *
+          exclude: "./.git/*"


### PR DESCRIPTION
Lint our Heroku buildpack shell scripts using [ShellCheck][1],
orchestrated in a GitHub Action by [reviewdog][2].

[1]: https://github.com/koalaman/shellcheck
[2]: https://github.com/reviewdog/action-shellcheck