### PR TITLE
Set reviewdog checks to check entire repo

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
+          filter_mode: nofilter
           path: "./bin"
           pattern: |
             *


### PR DESCRIPTION
Prior to this commit reviewdog was only failing if it found linting
errors in the given diff.  Now it checks the entire repo which is what
we want - i.e. a ["no broken windows" policy][1].

[1]: https://www.artima.com/articles/dont-live-with-broken-windows