### PR TITLE
Check spelling on push and PR

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -53,3 +53,14 @@ jobs:
           language: en
           disabled_rules:
             "GITHUB,DASH_RULE,PUNCTUATION_PARAGRAPH_END"
+
+  misspell:
+    name: runner / misspell
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - uses: reviewdog/action-misspell@v1.12.2
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-check
+          filter_mode: nofilter


### PR DESCRIPTION
Use [misspell][1] to check spelling, orchestrated by [reviewdog][2].

[1]: https://github.com/client9/misspell
[2]: https://github.com/reviewdog/action-misspell